### PR TITLE
Adding Load_balancing_type Variable into Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Description: The type of the AVD Host Pool. Valid values are 'Pooled' and 'Perso
 
 Type: `string`
 
-### <a name="input_Load_balancer_type"></a> [Load_balancing_Type](#input\_location)
+### <a name="input_load_balancer_type"></a> [load_balancing_type](#input\_load_balancer_type)
 
 Description: The type of load balancing for the AVD Host Pool. Valid values are "BreadthFirst" or "DepthFirst".
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Description: The type of the AVD Host Pool. Valid values are 'Pooled' and 'Perso
 
 Type: `string`
 
+### <a name="input_Load_balancer_type"></a> [Load_balancing_Type](#input\_location)
+
+Description: The type of load balancing for the AVD Host Pool. Valid values are "BreadthFirst" or "DepthFirst".
+
+Type: `string`
+
 ### <a name="input_location"></a> [location](#input\_location)
 
 Description: The Azure location where the resources will be deployed.

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ resource "azurerm_virtual_desktop_host_pool" "hostpool" {
   description              = "HostPool"
   type                     = var.hostpooltype # ["Pooled" "Personal"]
   maximum_sessions_allowed = var.maxsessions
-  load_balancer_type       = "BreadthFirst" #["BreadthFirst" "DepthFirst"]
+  load_balancer_type       = var.load_balancing_type #["BreadthFirst" "DepthFirst"]
   start_vm_on_connect      = "true"         # [true false]
   tags                     = var.tags
   scheduled_agent_updates {

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,11 @@ variable "maxsessions" {
   default     = 16
 }
 
+variable "load_balancing_type" {
+  type        = string
+  description = "The type of load balancing for the Host Pool, Either BreadthFirst or DepthFirst"
+}
+
 variable "day_of_week" {
   type        = string
   description = "The day of the week to apply the schedule agent update. Value must be one of: 'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', or 'Saturday'."


### PR DESCRIPTION
As described in the initial issue here: #9 The load balancing type was hardcoded to "BreadthFirst". 

This PR includes the new variable load_balancing_type that is a string that requires either "BreadthFirst" or "DepthFirst"