### PR TITLE
Force semicolon at the end of custom_properties

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -10,19 +10,23 @@ locals {
     ]
   ]) : "${assoc.pe_key}-${assoc.asg_key}" => assoc }
   # Convert RDP properties map to Azure-expected string format
-  rdp_properties_string = join(";", concat([
-    "drivestoredirect:s:${var.virtual_desktop_host_pool_custom_rdp_properties.drivestoredirect}",
-    "audiomode:i:${var.virtual_desktop_host_pool_custom_rdp_properties.audiomode}",
-    "videoplaybackmode:i:${var.virtual_desktop_host_pool_custom_rdp_properties.videoplaybackmode}",
-    "redirectclipboard:i:${var.virtual_desktop_host_pool_custom_rdp_properties.redirectclipboard}",
-    "redirectprinters:i:${var.virtual_desktop_host_pool_custom_rdp_properties.redirectprinters}",
-    "devicestoredirect:s:${var.virtual_desktop_host_pool_custom_rdp_properties.devicestoredirect}",
-    "redirectcomports:i:${var.virtual_desktop_host_pool_custom_rdp_properties.redirectcomports}",
-    "redirectsmartcards:i:${var.virtual_desktop_host_pool_custom_rdp_properties.redirectsmartcards}",
-    "usbdevicestoredirect:s:${var.virtual_desktop_host_pool_custom_rdp_properties.usbdevicestoredirect}",
-    "enablecredsspsupport:i:${var.virtual_desktop_host_pool_custom_rdp_properties.enablecredsspsupport}",
-    "use multimon:i:${var.virtual_desktop_host_pool_custom_rdp_properties.use_multimon}"
-    ], [
-    for key, value in var.virtual_desktop_host_pool_custom_rdp_properties.custom_properties : "${key}:${value}"
-  ]))
+  rdp_properties_string = join(";", concat(
+    [
+      "drivestoredirect:s:${var.virtual_desktop_host_pool_custom_rdp_properties.drivestoredirect}",
+      "audiomode:i:${var.virtual_desktop_host_pool_custom_rdp_properties.audiomode}",
+      "videoplaybackmode:i:${var.virtual_desktop_host_pool_custom_rdp_properties.videoplaybackmode}",
+      "redirectclipboard:i:${var.virtual_desktop_host_pool_custom_rdp_properties.redirectclipboard}",
+      "redirectprinters:i:${var.virtual_desktop_host_pool_custom_rdp_properties.redirectprinters}",
+      "devicestoredirect:s:${var.virtual_desktop_host_pool_custom_rdp_properties.devicestoredirect}",
+      "redirectcomports:i:${var.virtual_desktop_host_pool_custom_rdp_properties.redirectcomports}",
+      "redirectsmartcards:i:${var.virtual_desktop_host_pool_custom_rdp_properties.redirectsmartcards}",
+      "usbdevicestoredirect:s:${var.virtual_desktop_host_pool_custom_rdp_properties.usbdevicestoredirect}",
+      "enablecredsspsupport:i:${var.virtual_desktop_host_pool_custom_rdp_properties.enablecredsspsupport}",
+      "use multimon:i:${var.virtual_desktop_host_pool_custom_rdp_properties.use_multimon}"
+    ],
+    [
+      for key, value in var.virtual_desktop_host_pool_custom_rdp_properties.custom_properties : "${key}:${value}"
+    ],
+    [""] # This enforces a semicolon at the end of the list, as this is the format required by Azure.
+  ))
 }


### PR DESCRIPTION
## Description

When using custom_rdp_properties, there was a problem where a drift was detected with every apply. The reason for this is that when queried by the Azure API, the custom_rdp_properties string always ends with a semicolon, unlike in this module.

That's why I added an empty string to the end of the array to force a trailing semicolon.

```
  # module.virtual_desktop.module.avm_res_desktopvirtualization_hostpool.azurerm_virtual_desktop_host_pool.this will be updated in-place
  ~ resource "azurerm_virtual_desktop_host_pool" "this" {
      ~ custom_rdp_properties    = "drivestoredirect:s:*;audiomode:i:0;videoplaybackmode:i:1;redirectclipboard:i:1;redirectprinters:i:1;devicestoredirect:s:*;redirectcomports:i:1;redirectsmartcards:i:1;usbdevicestoredirect:s:*;enablecredsspsupport:i:1;use multimon:i:1;enablerdsaadauth:i:1;audiocapturemode:i:0;" -> "drivestoredirect:s:*;audiomode:i:0;videoplaybackmode:i:1;redirectclipboard:i:1;redirectprinters:i:1;devicestoredirect:s:*;redirectcomports:i:1;redirectsmartcards:i:1;usbdevicestoredirect:s:*;enablecredsspsupport:i:1;use multimon:i:1;audiocapturemode:i:0;enablerdsaadauth:i:1"
        id                       = "/subscriptions/d762d375-0da5-45e8-bd55-c68719949c77/resourceGroups/rg-demo-avd-prd-gwc-main/providers/Microsoft.DesktopVirtualization/hostPools/vdpool-demo-avd-pooled"
        name                     = "vdpool-demo-avd-pooled"
        tags                     = {}
        # (9 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }
```

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [X] Azure Verified Module updates:
  - [X] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [X] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->


---

Fixes #117

<!-- gh-aw-workflow-id: issue-triage -->